### PR TITLE
react-query: type safety for `QueryKey`

### DIFF
--- a/buildSrc/src/main/kotlin/karakum/query/Type.kt
+++ b/buildSrc/src/main/kotlin/karakum/query/Type.kt
@@ -6,7 +6,7 @@ private val SPECIAL_TYPES = setOf(
     "TOutput | DataUpdateFunction<TInput, TOutput>",
 )
 
-private const val QUERY_KEY="QueryKey"
+private const val QUERY_KEY = "QueryKey"
 
 class Type(
     override val source: String,
@@ -71,7 +71,10 @@ class Type(
                     .replace("mutation: Mutation", "mutation: Mutation<*, *, *, *>")
                     .replace("mutation?: Mutation", "mutation: Mutation<*, *, *, *>?")
                     .replace("event?: QueryCacheNotifyEvent", "event: QueryCacheNotifyEvent?")
-                    .replace("options?: MutateOptions<TData, TError, TVariables, TContext>", "options: MutateOptions<TData, TError, TVariables, TContext>?")
+                    .replace(
+                        "options?: MutateOptions<TData, TError, TVariables, TContext>",
+                        "options: MutateOptions<TData, TError, TVariables, TContext>?"
+                    )
             }
 
             else -> "Any"
@@ -109,10 +112,10 @@ class Type(
         if (body.toIntOrNull() != null)
             return "const val $name = $body"
 
-        if (name == "QueryKey")
+        if (name == QUERY_KEY)
             return """
                 // $body 
-                external interface QueryKey
+                external interface $QUERY_KEY
                 """.trimIndent()
 
         return "typealias $name${formatParameters(typeParameters)} = $body"

--- a/buildSrc/src/main/kotlin/karakum/query/Type.kt
+++ b/buildSrc/src/main/kotlin/karakum/query/Type.kt
@@ -115,7 +115,7 @@ class Type(
         if (name == QUERY_KEY)
             return """
                 // $body 
-                external interface $QUERY_KEY
+                external interface $name
                 """.trimIndent()
 
         return "typealias $name${formatParameters(typeParameters)} = $body"

--- a/buildSrc/src/main/kotlin/karakum/query/Type.kt
+++ b/buildSrc/src/main/kotlin/karakum/query/Type.kt
@@ -6,6 +6,8 @@ private val SPECIAL_TYPES = setOf(
     "TOutput | DataUpdateFunction<TInput, TOutput>",
 )
 
+private const val QUERY_KEY="QueryKey"
+
 class Type(
     override val source: String,
     fixAction: Boolean,
@@ -47,6 +49,8 @@ class Type(
             body in SPECIAL_TYPES -> body.substringAfterLast(" | ")
 
             body.toIntOrNull() != null -> body
+
+            name == QUERY_KEY -> body
 
             "|" in body -> "Union /* $body */"
 
@@ -104,6 +108,12 @@ class Type(
 
         if (body.toIntOrNull() != null)
             return "const val $name = $body"
+
+        if (name == "QueryKey")
+            return """
+                // $body 
+                external interface QueryKey
+                """.trimIndent()
 
         return "typealias $name${formatParameters(typeParameters)} = $body"
     }

--- a/react-query-kotlin/src/main/kotlin/react/query/types.core.kt
+++ b/react-query-kotlin/src/main/kotlin/react/query/types.core.kt
@@ -11,7 +11,8 @@ import kotlinx.js.Record
 import kotlinx.js.Void
 import kotlin.js.Promise
 
-typealias QueryKey = Union /* string | readonly unknown[] */
+// string | readonly unknown[] 
+external interface QueryKey
 
 typealias EnsuredQueryKey<T> = Any
 


### PR DESCRIPTION
cc: @turansky 